### PR TITLE
Remove flaky tests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,6 @@ Imports:
     withr
 Suggests:
     mockery,
-    processx,
     rmarkdown,
     testthat
 Remotes:

--- a/tests/testthat/test-orderly-run-session.R
+++ b/tests/testthat/test-orderly-run-session.R
@@ -50,8 +50,9 @@ test_that("run failing report", {
     source(script)
   }
   mockery::stub(orderly_run_session, "rstudioapi::jobRunScript", run)
-  orderly_run_session("minimal", parameters = NULL,
-                      instance = NULL, root = path)
+  expect_error(orderly_run_session("minimal", parameters = NULL,
+                                   instance = NULL, root = path),
+               "some error")
   reports <- list.files(file.path(path, "draft", "minimal"),
                         full.names = TRUE)
   expect_length(reports, 1)

--- a/tests/testthat/test-orderly-run-session.R
+++ b/tests/testthat/test-orderly-run-session.R
@@ -14,27 +14,9 @@ test_that("run report", {
   })
 })
 
-test_that("run report", {
-  path <- orderly_prepare_orderly_example("demo")
-  run <- function(script, workingDir) {
-    processx::process$new(file.path(R.home(), "bin", "Rscript"), script)
-  }
-  mockery::stub(orderly_run_session, "rstudioapi::jobRunScript", run)
-  orderly_run_session("other", parameters = list(nmin = 0.1),
-                      instance = NULL, root = path)
-  Sys.sleep(15)
-  reports <- list.files(file.path(path, "draft", "other"),
-                        full.names = TRUE)
-  expect_length(reports, 1)
-  expect_true(file.exists(file.path(reports, "orderly_run.rds")))
-})
-
 test_that("run report and commit", {
+  skip_if_not_rstudio()
   path <- orderly_prepare_orderly_example("demo")
-  run <- function(script, workingDir) {
-    processx::process$new(file.path(R.home(), "bin", "Rscript"), script)
-  }
-  mockery::stub(orderly_run_session, "rstudioapi::jobRunScript", run)
   orderly_run_session("other", parameters = list(nmin = 0.1),
                       instance = NULL, root = path, commit = TRUE)
   testthat::try_again(5, {
@@ -47,13 +29,10 @@ test_that("run report and commit", {
 })
 
 test_that("run failing report", {
+  skip_if_not_rstudio()
   path <- orderly_prepare_orderly_example("demo")
   append_lines('stop("some error")',
                file.path(path, "src", "minimal", "script.R"))
-  run <- function(script, workingDir) {
-    processx::process$new(file.path(R.home(), "bin", "Rscript"), script)
-  }
-  mockery::stub(orderly_run_session, "rstudioapi::jobRunScript", run)
   orderly_run_session("minimal", parameters = NULL,
                       instance = NULL, root = path)
   testthat::try_again(5, {
@@ -97,7 +76,7 @@ test_that("run report works from report working directory", {
     orderly_run_session("other", parameters = list(nmin = 0.1))
   })
   testthat::try_again(5, {
-    Sys.sleep(1)
+    Sys.sleep(2)
     reports <- list.files(file.path(path, "draft", "other"),
                           full.names = TRUE)
     expect_length(reports, 1)

--- a/tests/testthat/test-orderly-run-session.R
+++ b/tests/testthat/test-orderly-run-session.R
@@ -90,7 +90,7 @@ test_that("run report works from report working directory", {
     orderly_run_session("other", parameters = list(nmin = 0.1))
   })
   testthat::try_again(5, {
-    Sys.sleep(2)
+    Sys.sleep(1)
     reports <- list.files(file.path(path, "draft", "other"),
                           full.names = TRUE)
     expect_length(reports, 1)

--- a/tests/testthat/test-orderly-run-session.R
+++ b/tests/testthat/test-orderly-run-session.R
@@ -14,7 +14,7 @@ test_that("run report", {
   })
 })
 
-test_that("run report mock", {
+test_that("run report with mock", {
   path <- orderly_prepare_orderly_example("demo")
   run <- function(script, workingDir) {
     source(script)

--- a/tests/testthat/test-orderly-run-session.R
+++ b/tests/testthat/test-orderly-run-session.R
@@ -1,6 +1,20 @@
 context("orderly_run_session")
 
 test_that("run report", {
+  skip_if_not_rstudio()
+  path <- orderly_prepare_orderly_example("demo")
+  orderly_run_session("other", parameters = list(nmin = 0.1),
+                      instance = NULL, root = path)
+  testthat::try_again(5, {
+    Sys.sleep(1)
+    reports <- list.files(file.path(path, "draft", "other"),
+                          full.names = TRUE)
+    expect_length(reports, 1)
+    expect_true(file.exists(file.path(reports, "orderly_run.rds")))
+  })
+})
+
+test_that("run report mock", {
   path <- orderly_prepare_orderly_example("demo")
   run <- function(script, workingDir) {
     source(script)

--- a/tests/testthat/test-orderly-run-session.R
+++ b/tests/testthat/test-orderly-run-session.R
@@ -1,47 +1,47 @@
 context("orderly_run_session")
 
 test_that("run report", {
-  skip_if_not_rstudio()
   path <- orderly_prepare_orderly_example("demo")
+  run <- function(script, workingDir) {
+    source(script)
+  }
+  mockery::stub(orderly_run_session, "rstudioapi::jobRunScript", run)
   orderly_run_session("other", parameters = list(nmin = 0.1),
                       instance = NULL, root = path)
-  testthat::try_again(5, {
-    Sys.sleep(1)
-    reports <- list.files(file.path(path, "draft", "other"),
-                          full.names = TRUE)
-    expect_length(reports, 1)
-    expect_true(file.exists(file.path(reports, "orderly_run.rds")))
-  })
+  reports <- list.files(file.path(path, "draft", "other"),
+                        full.names = TRUE)
+  expect_length(reports, 1)
+  expect_true(file.exists(file.path(reports, "orderly_run.rds")))
 })
 
 test_that("run report and commit", {
-  skip_if_not_rstudio()
   path <- orderly_prepare_orderly_example("demo")
+  run <- function(script, workingDir) {
+    source(script)
+  }
+  mockery::stub(orderly_run_session, "rstudioapi::jobRunScript", run)
   orderly_run_session("other", parameters = list(nmin = 0.1),
                       instance = NULL, root = path, commit = TRUE)
-  testthat::try_again(5, {
-    Sys.sleep(1)
-    reports <- list.files(file.path(path, "archive", "other"),
-                          full.names = TRUE)
-    expect_length(reports, 1)
-    expect_true(file.exists(file.path(reports, "orderly_run.rds")))
-  })
+  reports <- list.files(file.path(path, "archive", "other"),
+                        full.names = TRUE)
+  expect_length(reports, 1)
+  expect_true(file.exists(file.path(reports, "orderly_run.rds")))
 })
 
 test_that("run failing report", {
-  skip_if_not_rstudio()
   path <- orderly_prepare_orderly_example("demo")
   append_lines('stop("some error")',
                file.path(path, "src", "minimal", "script.R"))
+  run <- function(script, workingDir) {
+    source(script)
+  }
+  mockery::stub(orderly_run_session, "rstudioapi::jobRunScript", run)
   orderly_run_session("minimal", parameters = NULL,
                       instance = NULL, root = path)
-  testthat::try_again(5, {
-    Sys.sleep(1)
-    reports <- list.files(file.path(path, "draft", "minimal"),
-                          full.names = TRUE)
-    expect_length(reports, 1)
-    expect_true(file.exists(file.path(reports, "orderly_fail.rds")))
-  })
+  reports <- list.files(file.path(path, "draft", "minimal"),
+                        full.names = TRUE)
+  expect_length(reports, 1)
+  expect_true(file.exists(file.path(reports, "orderly_fail.rds")))
 })
 
 test_that("args are passed to run script", {


### PR DESCRIPTION
Spent a while adding print lines trying to get these tests to work. But they proved pretty awkward and seem to pass fine when I am capturing the output. I was previously trying to be clever with the tests, switching out the jobrunscript for processx when testing but figured it would be ok to just remove this.

Downside is this function won't be tested end-to-end on CI, I could add a test with just mocks out the call to jobrunscript and check contents of saved out RDS